### PR TITLE
Add styling constraints to cards, add an in-between media query

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -272,6 +272,10 @@ body {
 
 .card-body {
   margin: 1rem;
+  height: 100%;
+  max-height: 20rem;
+  min-height: 8rem;
+  overflow: auto;
 }
 
 .card-idea-title {
@@ -333,7 +337,22 @@ body {
 
 /*=== media queries ===*/
 
-@media only screen and (max-width: 925px) {
+@media (min-width: 425px) and (max-width: 940px){
+  .all-cards {
+    display: flex!important;
+    flex-direction: row!important;
+    flex-wrap: wrap!important;
+    justify-content: center;
+  }
+
+  .card {
+    max-width: 20rem;
+    width: 100%;
+    margin: 1rem;
+  }
+}
+
+@media only screen and (max-width: 940px) {
   body {
     flex-direction: column;
   }
@@ -356,6 +375,8 @@ body {
   }
 
   .card {
+    display: flex;
+    flex-direction: column;
     margin-bottom: 2rem;
   }
 }
@@ -378,7 +399,7 @@ body {
   }
 } */
 
-@media (min-width: 925px) {
+@media (min-width: 940px) {
   body {
     display: grid;
     grid-template-columns: 1fr 3fr;


### PR DESCRIPTION

#### What's this PR do?

- adds constraints to the sizing of cards in the all-cards section
- adds a media query that turns the all-cards section into a flex-box between 425px to 940px to add more steps of responsiveness

#### Where should the reviewer start?

styles.css - line 340

#### How should this be manually tested?

stretch and squash the page in the 'responsiveness' section of the dev tools

#### Any background context you want to provide?

- used the 'and' command between two parens of media queries to add upper and lower constraints to the styling. very useful!

#### What are the relevant tickets?

- sometimes the regular browser window and the 'responsiveness' window have slightly different break points. needs more testing
- the 'iPad pro' looks a bit rough for some reason. needs more research
