### PR TITLE
Fixes gray overlay on open menu on mobile view

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@ var ideaText = document.querySelector('.card-idea-text');
 var bubbleParent = document.querySelector('.purple-1');
 var ideaForm = document.querySelector('.idea-form');
 var allCards = document.querySelector('.all-cards');
-var deleteIcon = document.querySelector('.card-delete-icon')
+var deleteIcon = document.querySelector('.card-delete-icon');
 
 var storage = [];
 
@@ -71,7 +71,7 @@ function saveButtonDisable() {
   }
 }
 
-function deleteIdea(){
+function deleteIdea() {
   var deleteSelection = event.target.closest(".card")
   deleteSelection.remove();
   for (var i = 0; i < storage.length; i++) {

--- a/styles.css
+++ b/styles.css
@@ -104,7 +104,7 @@ body {
   top: 0;
   right: 0;
   left: 0;
-  position: absolute;
+  position: fixed;
   z-index: 1;
 }
 
@@ -426,6 +426,7 @@ body {
     flex-direction: column;
     align-items: center;
     height: 100%;
+
   }
 
   .menu-header-icon {


### PR DESCRIPTION
#### What's this PR do?

- This fixes the gray overlay that appears in the open menu view on mobile. 

#### Where should the reviewer start?

- In styles.css, the reviewer can start on line 103. 

#### How should this be manually tested?

-After removing the hidden class, the tester can view the overlay on index.html. Tester should see the gray overlay extend down to the bottom of the view. 

#### What are the relevant tickets?

-There is still an issue with the sidebar on desktop view not extending the length of the screen. 

