### PR TITLE
Show Saved Ideas Functionality

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -139,7 +139,7 @@ function toggleFavorite(event) {
     if (favorite.dataset.id === `${storage[i].id}` && !storage[i].star) {
       storage[i].star = true;
       storage[i].updateIdea(storage);
-    } else {
+    } else if (favorite.dataset.id === `${storage[i].id}` && storage[i].star) {
       storage[i].star = false;
       storage[i].updateIdea(storage);
     };

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,7 @@ var menuHeaderIcon = document.querySelector('.menu-header-icon');
 var mobileMenu = document.querySelector('.open-nav-filter');
 var overlay = document.querySelector('.whole-filter-section');
 var closeIcon = document.querySelector('.menu-nav-close-icon');
+var showStarredButton = document.querySelectorAll('.show-starred-ideas');
 
 var storage = [];
 
@@ -29,6 +30,7 @@ function clickHandler(event) {
   if (event.target.classList.contains("card-star-favorite-icon")) starIdeaButton();
   if (event.target.className === "menu-header-icon") openNav();
   if (event.target.className === "menu-nav-close-icon") closeNav();
+  if (event.target.className === "show-starred-ideas") starHandler();
 }
 
 function keyHandler(event) {
@@ -143,6 +145,35 @@ function toggleFavorite(event) {
       storage[i].star = false;
       storage[i].updateIdea(storage);
     };
+  };
+}
+
+function starHandler() {
+  console.log(showStarredButton[0].innerText);
+  if (showStarredButton[0].innerText === "Show All Ideas") {
+    restoreIdeas();
+  } else {
+    starredIdeas();
+  };
+}
+
+function starredIdeas() {
+  showStarredButton[0].innerText = "Show All Ideas";
+  showStarredButton[1].innerText = "Show All Ideas";
+  allCards.innerHTML = "";
+  for (var i = 0; i < storage.length; i++) {
+    if (storage[i].star) {
+      buildCard(storage[i]);
+    };
+  };
+}
+
+function restoreIdeas() {
+  showStarredButton[0].innerText = "Show Starred Ideas";
+  showStarredButton[1].innerText = "Show Starred Ideas";
+  allCards.innerHTML = "";
+  for (var i = 0; i < storage.length; i++) {
+    buildCard(storage[i]);
   };
 }
 


### PR DESCRIPTION
#### What's this PR do?

- This PR adds three functions to enable the functionality for the button "Show Starred Ideas."
- starHandler is a function handler called in the event listener and contains two other functions: starredIdeas() and restoreIdeas().
- We also refactored the toggleFavorite function to fix a bug affecting the star image persisting through refresh. 

#### Where should the reviewer start?

- The reviewer should start in main.js.

#### How should this be manually tested?

- On the browser, with some cards favorited, the tester can click on the Show Starred Ideas button. The tester should see only favorited cards appear on the screen and the text of the button should change to Show All Ideas. When the button is clicked again, the tester should see all cards again and the text should revert back to Show Starred Ideas.

#### Screenshots (if appropriate):
<img width="1186" alt="Screen Shot 2020-07-29 at 1 57 09 PM" src="https://user-images.githubusercontent.com/66034248/88846884-7d488300-d1a3-11ea-8689-9668797db777.png">

